### PR TITLE
Upgrade to Anserini v0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <hbase.version>1.2.6</hbase.version>
-    <hadoop.version>3.0.3</hadoop.version>
-    <spark.version>2.3.1</spark.version>
+    <hadoop.version>2.6.5</hadoop.version>
+    <spark.version>2.4.4</spark.version>
   </properties>
 
   <build>
@@ -58,10 +58,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>8</source>
+          <target>8</target>
+          <testSource>8</testSource>
+          <testTarget>8</testTarget>
+          <showDeprecation>true</showDeprecation>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>
       <plugin>
@@ -268,7 +272,7 @@
     <dependency>
       <groupId>io.anserini</groupId>
       <artifactId>anserini</artifactId>
-      <version>0.2.0</version>
+      <version>0.6.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/scala/io/anserini/spark/IndexLoader.scala
+++ b/src/main/scala/io/anserini/spark/IndexLoader.scala
@@ -71,7 +71,9 @@ class IndexLoader(sc: JavaSparkContext, path: String) {
     * @return an RDD of document IDs
     */
   def docids(num: Integer): JavaRDD[Integer] = {
-    sc.parallelize(IntStream.rangeClosed(0, num).boxed().collect(Collectors.toList()))
+    // sc.parallelize(IntStream.rangeClosed(0, num).boxed().collect(Collectors.toList()))
+    // This doesn't work for Java 11: Static methods in interface require -target:jvm-1.8
+    sc.parallelize(0 to num toList).map(i => i : java.lang.Integer).toJavaRDD()
   }
 
   /**


### PR DESCRIPTION
Bumped up Anserini dependency to v0.6.0 - based on Lucene 8.0.0.
Still need Java 8 to run.
